### PR TITLE
Various api review

### DIFF
--- a/api/crds/policy.kubevault.com_vaultpolicybindings.yaml
+++ b/api/crds/policy.kubevault.com_vaultpolicybindings.yaml
@@ -414,10 +414,6 @@ spec:
         spec:
           description: 'links: https://www.vaultproject.io/api/auth/kubernetes/index.html#parameters-1'
           properties:
-            authPath:
-              description: 'Specifies the path where kubernetes auth is enabled default
-                : kubernetes'
-              type: string
             maxTTL:
               description: Specifies the maximum allowed lifetime of tokens issued
                 in seconds using this role.
@@ -433,8 +429,6 @@ spec:
               items:
                 type: string
               type: array
-            roleName:
-              type: string
             serviceAccountNames:
               description: Specifies the names of the service account to bind with
                 policy
@@ -486,6 +480,9 @@ spec:
             phase:
               description: Phase indicates whether successfully bind the policy to
                 service account in vault or not or in progress
+              type: string
+            roleName:
+              description: 'ref: https://www.vaultproject.io/docs/auth/kubernetes.html#configuration'
               type: string
           type: object
       type: object

--- a/apis/config/v1alpha1/openapi_generated.go
+++ b/apis/config/v1alpha1/openapi_generated.go
@@ -15653,7 +15653,7 @@ func schema_operator_apis_config_v1alpha1_VaultServerConfiguration(ref common.Re
 					},
 					"serviceAccountName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specifies the service account name",
+							Description: "Specifies the service account name, usually the vault server service account",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15686,7 +15686,7 @@ func schema_operator_apis_config_v1alpha1_VaultServerConfiguration(ref common.Re
 							Format:      "",
 						},
 					},
-					"authPath": {
+					"kubernetesAuthPath": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies the path where kubernetes auth is enabled default : kubernetes",
 							Type:        []string{"string"},

--- a/apis/config/v1alpha1/vault_server_config_types.go
+++ b/apis/config/v1alpha1/vault_server_config_types.go
@@ -13,7 +13,7 @@ type VaultServerConfiguration struct {
 	// +optional
 	metav1.TypeMeta `json:",inline,omitempty"`
 
-	// Specifies the service account name
+	// Specifies the service account name, usually the vault server service account
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
@@ -40,5 +40,5 @@ type VaultServerConfiguration struct {
 	// Specifies the path where kubernetes auth is enabled
 	// default : kubernetes
 	// +optional
-	AuthPath string `json:"authPath,omitempty"`
+	KubernetesAuthPath string `json:"kubernetesAuthPath,omitempty"`
 }

--- a/apis/engine/v1alpha1/aws_role_types.go
+++ b/apis/engine/v1alpha1/aws_role_types.go
@@ -39,11 +39,32 @@ const (
 	AWSCredentialFederationToken AWSCredentialType = "federation_token"
 )
 
-// AWSRoleSpec contains connection information, AWS role info, etc
-type AWSRoleSpec struct {
+
+type SecretEngine struct {
+	// spec
 	Ref *appcat.AppReference `json:"ref,omitempty"`
 
+	EngineType string
+	EnginePath string
+
 	Config *AWSConfig `json:"config"`
+	SkipActivation bool
+
+	// status
+	PolicyName string
+}
+
+// AWSRoleSpec contains connection information, AWS role info, etc
+type AWSRoleSpec struct {
+	Enginename string
+
+	//Ref *appcat.AppReference `json:"ref,omitempty"`
+	//
+	//Config *AWSConfig `json:"config"`
+	//
+	//AWSPath string `json:"awsPath,omitempty"`
+
+
 
 	// links:
 	// 	- https://www.vaultproject.io/api/secret/aws/index.html

--- a/apis/policy/v1alpha1/openapi_generated.go
+++ b/apis/policy/v1alpha1/openapi_generated.go
@@ -15886,19 +15886,6 @@ func schema_operator_apis_policy_v1alpha1_VaultPolicyBindingSpec(ref common.Refe
 				Description: "links: https://www.vaultproject.io/api/auth/kubernetes/index.html#parameters-1",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"roleName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"authPath": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies the path where kubernetes auth is enabled default : kubernetes",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"policies": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies the names of the VaultPolicy",
@@ -15979,6 +15966,13 @@ func schema_operator_apis_policy_v1alpha1_VaultPolicyBindingStatus(ref common.Re
 						SchemaProps: spec.SchemaProps{
 							Description: "observedGeneration is the most recent generation observed for this resource. It corresponds to the resource's generation, which is updated on mutation by the API Server.",
 							Ref:         ref("github.com/appscode/go/encoding/json/types.IntHash"),
+						},
+					},
+					"roleName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ref: https://www.vaultproject.io/docs/auth/kubernetes.html#configuration",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"phase": {

--- a/apis/policy/v1alpha1/vaultpolicybinding_helpers.go
+++ b/apis/policy/v1alpha1/vaultpolicybinding_helpers.go
@@ -15,10 +15,6 @@ func (v VaultPolicyBinding) GetKey() string {
 }
 
 func (v VaultPolicyBinding) PolicyBindingName() string {
-	if v.Spec.RoleName != "" {
-		return v.Spec.RoleName
-	}
-
 	cluster := "-"
 	if clusterid.ClusterName() != "" {
 		cluster = clusterid.ClusterName()
@@ -82,13 +78,5 @@ func (v VaultPolicyBinding) IsValid() error {
 func (v *VaultPolicyBinding) SetDefaults() {
 	if v == nil {
 		return
-	}
-
-	if v.Spec.RoleName == "" {
-		v.Spec.RoleName = v.PolicyBindingName()
-	}
-
-	if v.Spec.AuthPath == "" {
-		v.Spec.AuthPath = "kubernetes"
 	}
 }

--- a/apis/policy/v1alpha1/vaultpolicybinding_types.go
+++ b/apis/policy/v1alpha1/vaultpolicybinding_types.go
@@ -30,14 +30,6 @@ type VaultPolicyBinding struct {
 
 // links: https://www.vaultproject.io/api/auth/kubernetes/index.html#parameters-1
 type VaultPolicyBindingSpec struct {
-	// +optional
-	RoleName string `json:"roleName,omitempty"`
-
-	// Specifies the path where kubernetes auth is enabled
-	// default : kubernetes
-	// +optional
-	AuthPath string `json:"authPath,omitempty"`
-
 	// Specifies the names of the VaultPolicy
 	Policies []string `json:"policies"`
 
@@ -89,6 +81,10 @@ type VaultPolicyBindingStatus struct {
 	// resource's generation, which is updated on mutation by the API Server.
 	// +optional
 	ObservedGeneration *types.IntHash `json:"observedGeneration,omitempty"`
+
+	// ref: https://www.vaultproject.io/docs/auth/kubernetes.html#configuration
+	// +optional
+	RoleName string `json:"roleName,omitempty"`
 
 	// Phase indicates whether successfully bind the policy to service account in vault or not or in progress
 	// +optional

--- a/pkg/controller/appbinding.go
+++ b/pkg/controller/appbinding.go
@@ -38,7 +38,7 @@ func (c *VaultController) ensureAppBindings(vs *api.VaultServer, v Vault) error 
 			Kind:       vaultconfig.ResourceKindVaultServerConfiguration,
 		},
 		UsePodServiceAccountForCSIDriver: true,
-		AuthPath:                         string(api.AuthTypeKubernetes),
+		KubernetesAuthPath:               string(api.AuthTypeKubernetes),
 		ServiceAccountName:               vs.ServiceAccountName(),
 		PolicyControllerRole:             vs.PolicyNameForPolicyController(),
 		AuthMethodControllerRole:         vaultPolicyBindingForAuthMethod(vs).PolicyBindingName(),

--- a/pkg/vault/auth/serviceaccount/login.go
+++ b/pkg/vault/auth/serviceaccount/login.go
@@ -64,8 +64,8 @@ func New(kc kubernetes.Interface, vApp *appcat.AppBinding) (*auth, error) {
 		return nil, errors.New("jwt is missing")
 	}
 
-	if cf.AuthPath == "" {
-		cf.AuthPath = string(vsapi.AuthTypeKubernetes)
+	if cf.KubernetesAuthPath == "" {
+		cf.KubernetesAuthPath = string(vsapi.AuthTypeKubernetes)
 	}
 	if cf.PolicyControllerRole == "" {
 		return nil, errors.Wrap(err, "policyControllerRole is empty")
@@ -75,7 +75,7 @@ func New(kc kubernetes.Interface, vApp *appcat.AppBinding) (*auth, error) {
 		vClient: vc,
 		jwt:     string(jwt),
 		role:    cf.PolicyControllerRole,
-		path:    cf.AuthPath,
+		path:    cf.KubernetesAuthPath,
 	}, nil
 }
 

--- a/pkg/vault/policybinding/policy_binding.go
+++ b/pkg/vault/policybinding/policy_binding.go
@@ -35,7 +35,7 @@ func NewPolicyBindingClient(c cs.Interface, appc appcat_cs.AppcatalogV1alpha1Int
 		ttl:          pBind.Spec.TTL,
 		maxTTL:       pBind.Spec.MaxTTL,
 		period:       pBind.Spec.Period,
-		path:         pBind.Spec.AuthPath,
+		path:         pBind.Spec.AuthPath, // GetAppBinding(pBind.Spec.policies[0]).Parameters.KubernetesAuthPath
 	}
 	pb.setDefaults()
 


### PR DESCRIPTION
- KubernetesAuthPath in AppBinding is used to create PolicyBinding
- PolicyBinding role name is always auto-generated