### PR TITLE
Add SSmKeyPrefix option

### DIFF
--- a/api/crds/kubevault.com_vaultservers.yaml
+++ b/api/crds/kubevault.com_vaultservers.yaml
@@ -5970,6 +5970,10 @@ spec:
                           description: The ID or ARN of the AWS KMS key to encrypt
                             values
                           type: string
+                        ssmKeyPrefix:
+                          description: An optional Key prefix for SSM Parameter store.
+                            values
+                          type: string
                         region:
                           type: string
                       required:

--- a/apis/kubevault/v1alpha1/openapi_generated.go
+++ b/apis/kubevault/v1alpha1/openapi_generated.go
@@ -15853,6 +15853,13 @@ func schema_operator_apis_kubevault_v1alpha1_AwsKmsSsmSpec(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"ssmKeyPrefix": {
+						SchemaProps: spec.SchemaProps{
+							Description: "An optional Key prefix for SSM Parameter store",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/apis/kubevault/v1alpha1/vaultserver_types.go
+++ b/apis/kubevault/v1alpha1/vaultserver_types.go
@@ -723,6 +723,9 @@ type AwsKmsSsmSpec struct {
 	KmsKeyID string `json:"kmsKeyID"`
 
 	// +optional
+	// An optional Key prefix for SSM Parameter store
+	SsmKeyPrefix string `json:"ssmKeyPrefix,omitempty"`
+
 	Region string `json:"region,omitempty"`
 
 	// Specifies the secret name containing AWS access key and AWS secret key

--- a/pkg/vault/unsealer/aws/aws_kms_ssm.go
+++ b/pkg/vault/unsealer/aws/aws_kms_ssm.go
@@ -43,6 +43,9 @@ func (o *Options) Apply(pt *core.PodTemplateSpec) error {
 	if o.KmsKeyID != "" {
 		args = append(args, fmt.Sprintf("--aws.kms-key-id=%s", o.KmsKeyID))
 	}
+	if o.SsmKeyPrefix != "" {
+		args = append(args, fmt.Sprintf("--aws.ssm-key-prefix=%s", o.SsmKeyPrefix))
+	}
 	cont.Args = append(cont.Args, args...)
 
 	var envs []core.EnvVar

--- a/pkg/vault/unsealer/aws/aws_kms_ssm_test.go
+++ b/pkg/vault/unsealer/aws/aws_kms_ssm_test.go
@@ -13,6 +13,7 @@ func TestOptions_Apply(t *testing.T) {
 	expected := []string{
 		"--mode=aws-kms-ssm",
 		"--aws.kms-key-id=test-key",
+		"--aws.ssm-key-prefix=/cluster/demo",
 	}
 	cont := corev1.Container{
 		Name: util.VaultUnsealerContainerName,
@@ -24,7 +25,8 @@ func TestOptions_Apply(t *testing.T) {
 	}
 
 	opts, err := NewOptions(api.AwsKmsSsmSpec{
-		KmsKeyID: "test-key",
+		KmsKeyID:     "test-key",
+		SsmKeyPrefix: "/cluster/demo",
 	})
 	assert.Nil(t, err)
 

--- a/test/e2e/vaultserver_test.go
+++ b/test/e2e/vaultserver_test.go
@@ -789,6 +789,7 @@ var _ = Describe("VaultServer", func() {
 					Mode: api.ModeSpec{
 						AwsKmsSsm: &api.AwsKmsSsmSpec{
 							KmsKeyID:         "65ed2c85-4915-4e82-be47-d56ccaa8019b",
+							SsmKeyPrefix:     "/cluster/demo",
 							Region:           "us-west-1",
 							CredentialSecret: awsCredSecret,
 						},


### PR DESCRIPTION
When using `awsKmsSsm` the sealer stores keys at the root of SSM.
While the sealer provides an option to define a prefix see `--aws.ssm-key-prefix string` at https://kubevault.com/docs/0.2.0/reference/unsealer/vault-unsealer_run/

This PR adds an `ssmKeyPrefix` in  `VaultServer` configuration