### PR TITLE
vault: add more env

### DIFF
--- a/pkg/controller/vault.go
+++ b/pkg/controller/vault.go
@@ -522,11 +522,38 @@ func (v *vaultSrv) GetContainer() core.Container {
 		Env: []core.EnvVar{
 			{
 				Name:  EnvVaultAddr,
-				Value: util.VaultServiceURL(v.vs.Name, v.vs.Namespace, VaultClientPort),
+				Value: util.VaultServiceURL(v.vs.OffshootName(), v.vs.Namespace, VaultClientPort),
 			},
 			{
 				Name:  EnvVaultClusterAddr,
-				Value: util.VaultServiceURL(v.vs.Name, v.vs.Namespace, VaultClusterPort),
+				Value: util.VaultServiceURL(v.vs.OffshootName(), v.vs.Namespace, VaultClusterPort),
+			},
+			{
+				Name: "HOSTNAME",
+				ValueFrom: &core.EnvVarSource{
+					FieldRef: &core.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.name",
+					},
+				},
+			},
+			{
+				Name: "HOST_IP",
+				ValueFrom: &core.EnvVarSource{
+					FieldRef: &core.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "status.hostIP",
+					},
+				},
+			},
+			{
+				Name: "POD_IP",
+				ValueFrom: &core.EnvVarSource{
+					FieldRef: &core.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "status.podIP",
+					},
+				},
 			},
 		},
 		SecurityContext: &core.SecurityContext{


### PR DESCRIPTION
Expose `HOSTNAME`, `POD_IP`, and `HOST_IP`.

In the process of adding a `StatefulSet` variant, those will be needed.

https://github.com/hashicorp/vault-helm/blob/8c741f6276c7320ae26885a31bfd2ce07f63e6a9/templates/server-statefulset.yaml#L103-L104