### PR TITLE
feat: expose cacert into vault container

### DIFF
--- a/pkg/controller/vault.go
+++ b/pkg/controller/vault.go
@@ -48,9 +48,11 @@ import (
 const (
 	EnvVaultAddr            = "VAULT_API_ADDR"
 	EnvVaultClusterAddr     = "VAULT_CLUSTER_ADDR"
+	EnvVaultCACert          = "VAULT_CACERT"
 	VaultClientPort         = 8200
 	VaultClusterPort        = 8201
 	vaultTLSAssetVolumeName = "vault-tls-secret"
+	TLSCACertKey            = "cacert.crt"
 )
 
 var (
@@ -176,6 +178,7 @@ func (v *vaultSrv) GetServerTLS() (*core.Secret, []byte, error) {
 		Data: map[string][]byte{
 			core.TLSCertKey:       srvCrt,
 			core.TLSPrivateKeyKey: srvKey,
+			TLSCACertKey:          store.CACertBytes(),
 		},
 	}
 	v.vs.Spec.TLS.CABundle = store.CACertBytes()
@@ -527,6 +530,10 @@ func (v *vaultSrv) GetContainer() core.Container {
 			{
 				Name:  EnvVaultClusterAddr,
 				Value: util.VaultServiceURL(v.vs.Name, v.vs.Namespace, VaultClusterPort),
+			},
+			{
+				Name:  EnvVaultCACert,
+				Value: fmt.Sprintf("%s%s", util.VaultTLSAssetDir, TLSCACertKey),
 			},
 		},
 		SecurityContext: &core.SecurityContext{


### PR DESCRIPTION
For the Raft backend #279 requires to have the ca cert somewhere (or as a string)

The goal is also to enable this,

```console
$ kubectl exec -it vault-0 vault -- vault status
```